### PR TITLE
feat: allow for `mode="backward"`

### DIFF
--- a/tests/timebasedsplit_test.py
+++ b/tests/timebasedsplit_test.py
@@ -16,15 +16,15 @@ RNG = np.random.default_rng()
 valid_kwargs = {
     "frequency": "days",
     "train_size": 7,
-    "forecast_horizon": 3,
-    "gap": 0,
-    "stride": 2,
+    "forecast_horizon": 4,
+    "gap": 1,
+    "stride": 3,
     "window": "rolling",
 }
 
 
 start_dt = pd.Timestamp(2023, 1, 1)
-end_dt = pd.Timestamp(2023, 3, 31)
+end_dt = pd.Timestamp(2023, 1, 31)
 
 time_series = pd.Series(pd.date_range(start_dt, end_dt, freq="D"))
 size = len(time_series)

--- a/timebasedcv/splitstate.py
+++ b/timebasedcv/splitstate.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import sys
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from operator import le as less_or_equal
-from typing import Generic
+from typing import TYPE_CHECKING, Generic, Union
 
 from timebasedcv.utils._funcs import pairwise, pairwise_comparison
 from timebasedcv.utils._types import DateTimeLike
@@ -13,6 +15,9 @@ else:  # pragma: no cover
     from typing_extensions import Self
 
 from narwhals.dependencies import get_pandas
+
+if TYPE_CHECKING:  # pragma: no cover
+    import pandas as pd
 
 
 @dataclass(frozen=True)
@@ -115,3 +120,21 @@ class SplitState(Generic[DateTimeLike]):
             A `timedelta` object representing the time between `train_start` and `forecast_end`.
         """
         return self.forecast_end - self.train_start
+
+    def __add__(self: Self, other: Union[timedelta, pd.Timedelta]) -> SplitState:
+        """Adds `other` to each value of the state."""
+        return SplitState(
+            train_start=self.train_start + other,
+            train_end=self.train_end + other,
+            forecast_start=self.forecast_start + other,
+            forecast_end=self.forecast_end + other,
+        )
+
+    def __sub__(self: Self, other: Union[timedelta, pd.Timedelta]) -> SplitState:
+        """Subtracts other to each value of the state."""
+        return SplitState(
+            train_start=self.train_start - other,
+            train_end=self.train_end - other,
+            forecast_start=self.forecast_start - other,
+            forecast_end=self.forecast_end - other,
+        )

--- a/timebasedcv/timebasedsplit.py
+++ b/timebasedcv/timebasedsplit.py
@@ -54,13 +54,15 @@ class _CoreTimeBasedSplit:
 
     Arguments:
         frequency: The frequency of the time series. Must be one of "days", "seconds", "microseconds", "milliseconds",
-            "minutes", "hours", "weeks". These are the only valid values for the `unit` argument of the `timedelta`.
+            "minutes", "hours", "weeks". These are the only valid values for the `unit` argument of `timedelta` from
+            python `datetime` standard library.
         train_size: The size of the training set.
-        forecast_horizon: The size of the forecast horizon.
+        forecast_horizon: The size of the forecast horizon, i.e. the size of the test set.
         gap: The size of the gap between the training set and the forecast horizon.
         stride: The size of the stride between consecutive splits. Notice that if stride is not provided (or set to 0),
-            it is set to `forecast_horizon`.
-        window: The type of window to use. Must be one of "rolling" or "expanding".
+            it fallbacks to the `forecast_horizon` quantity.
+        window: The type of window to use, either "rolling" or "expanding".
+        mode: Determines in which orders the splits are generated, either "forward" or "backward".
 
     Raises:
         ValueError: If `frequency` is not one of "days", "seconds", "microseconds", "milliseconds", "minutes", "hours",
@@ -266,13 +268,15 @@ class TimeBasedSplit(_CoreTimeBasedSplit):
 
     Arguments:
         frequency: The frequency of the time series. Must be one of "days", "seconds", "microseconds", "milliseconds",
-            "minutes", "hours", "weeks". These are the only valid values for the `unit` argument of the `timedelta`.
+            "minutes", "hours", "weeks". These are the only valid values for the `unit` argument of `timedelta` from
+            python `datetime` standard library.
         train_size: The size of the training set.
-        forecast_horizon: The size of the forecast horizon.
+        forecast_horizon: The size of the forecast horizon, i.e. the size of the test set.
         gap: The size of the gap between the training set and the forecast horizon.
         stride: The size of the stride between consecutive splits. Notice that if stride is not provided (or set to 0),
-            it is set to `forecast_horizon`.
-        window: The type of window to use. Must be one of "rolling" or "expanding".
+            it fallbacks to the `forecast_horizon` quantity.
+        window: The type of window to use, either "rolling" or "expanding".
+        mode: Determines in which orders the splits are generated, either "forward" or "backward".
 
     Raises:
         ValueError: If `frequency` is not one of "days", "seconds", "microseconds", "milliseconds", "minutes", "hours",
@@ -499,6 +503,7 @@ class ExpandingTimeSplit(TimeBasedSplit):  # pragma: no cover
         forecast_horizon: int,
         gap: int = 0,
         stride: Union[int, None] = None,
+        mode: ModeType,
     ) -> None:
         super().__init__(
             frequency=frequency,
@@ -507,6 +512,7 @@ class ExpandingTimeSplit(TimeBasedSplit):  # pragma: no cover
             gap=gap,
             stride=stride,
             window="expanding",
+            mode=mode,
         )
 
 
@@ -523,6 +529,7 @@ class RollingTimeSplit(TimeBasedSplit):  # pragma: no cover
         forecast_horizon: int,
         gap: int = 0,
         stride: Union[int, None] = None,
+        mode: ModeType,
     ) -> None:
         super().__init__(
             frequency=frequency,
@@ -531,6 +538,7 @@ class RollingTimeSplit(TimeBasedSplit):  # pragma: no cover
             gap=gap,
             stride=stride,
             window="rolling",
+            mode=mode,
         )
 
 
@@ -549,9 +557,10 @@ class TimeBasedCVSplitter(BaseCrossValidator):
 
     Arguments:
         frequency: The frequency of the time series. Must be one of "days", "seconds", "microseconds", "milliseconds",
-            "minutes", "hours", "weeks". These are the only valid values for the `unit` argument of the `timedelta`.
+            "minutes", "hours", "weeks". These are the only valid values for the `unit` argument of `timedelta` from
+            python `datetime` standard library.
         train_size: The size of the training set.
-        forecast_horizon: The size of the forecast horizon.
+        forecast_horizon: The size of the forecast horizon, i.e. the size of the test set.
         time_series: The time series used to create boolean mask for splits. It is not required to be sorted, but it
             must support:
 
@@ -561,8 +570,9 @@ class TimeBasedCVSplitter(BaseCrossValidator):
             - `.shape` attribute.
         gap: The size of the gap between the training set and the forecast horizon.
         stride: The size of the stride between consecutive splits. Notice that if stride is not provided (or set to 0),
-            it is set to `forecast_horizon`.
-        window: The type of window to use. Must be one of "rolling" or "expanding".
+            it fallbacks to the `forecast_horizon` quantity.
+        window: The type of window to use, either "rolling" or "expanding".
+        mode: Determines in which orders the splits are generated, either "forward" or "backward".
         start_dt: The start of the time period. If provided, it is used in place of the `time_series.min()`.
         end_dt: The end of the time period. If provided,it is used in place of the `time_series.max()`.
 

--- a/timebasedcv/utils/_types.py
+++ b/timebasedcv/utils/_types.py
@@ -22,6 +22,7 @@ NullableDatetime = Union[DateTimeLike, None]
 
 FrequencyUnit: TypeAlias = Literal["days", "seconds", "microseconds", "milliseconds", "minutes", "hours", "weeks"]
 WindowType: TypeAlias = Literal["rolling", "expanding"]
+ModeType: TypeAlias = Literal["forward", "backward"]
 
 T = TypeVar("T")
 


### PR DESCRIPTION
# Description

Implements the possibility to specify `mode="backward"` so that splits are generate from the end to the beginning.

Notice that this (implementation) implies that:

- test size will always correspond to `forecast_horizon` for backward mode, while it is not necessarily the case in forward mode
- train size will always be of size at least `train_size` in both mode's and both window's type

Fix #41 

## TODO

Add specific tests for checking forward vs backward swaps

